### PR TITLE
Add Travis CI testing and Coveralls.io reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: emacs-lisp
+before_install:
+  # PPA for stable Emacs packages
+  - sudo add-apt-repository -y ppa:cassou/emacs
+  # PPA for Emacs nightlies
+  - sudo add-apt-repository -y ppa:ubuntu-elisp/ppa
+  # Update and install the Emacs for our environment
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq -yy ${EMACS}-nox ${EMACS}-el
+  # Install cask dependencies
+  - curl -fsSLo /tmp/cask-master.zip https://github.com/cask/cask/archive/master.zip
+  - sudo unzip -qq -d /opt /tmp/cask-master.zip
+  - sudo ln -sf /opt/cask-master/bin/cask /usr/local/bin/cask
+  - cask
+env:
+  - EMACS=emacs24
+  - EMACS=emacs-snapshot
+script:
+  - emacs --version
+  - make test

--- a/Cask
+++ b/Cask
@@ -1,0 +1,5 @@
+(source gnu)
+(source melpa)
+
+(development
+ (depends-on "undercover"))

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+EMACS ?= emacs
+CASK_EXEC ?= cask exec
+
+all: test
+
+test: clean-elc
+	${MAKE} unit
+
+unit:
+	${CASK_EXEC} ${EMACS} -Q -batch -l tiny-test.el -l tiny.el --eval "(ert t)"
+
+compile:
+	${CASK_EXEC} ${EMACS} -Q -batch -f batch-byte-compile tiny.el
+
+clean-elc:
+	rm -f f.elc
+
+.PHONY:	all test

--- a/tiny-test.el
+++ b/tiny-test.el
@@ -1,4 +1,7 @@
-(require 'tiny)
+(when (require 'undercover nil t)
+  (undercover "tiny.el"))
+
+(require 'tiny nil t)
 
 (defun with-text-value (txt fn &rest args)
   "Return the result of (apply 'FN ARGS), in a temp buffer with TXT,


### PR DESCRIPTION
Here's some code that will let you use Travis CI and Coveralls.io for integration testing and code coverage reporting. (More lovely badges for your README.md!) =) I'm working on borrowing good programming practices from other communities, and I like how automated testing and code coverage reporting are popular for Rails gems and Node modules. I figure that if we get more of these little examples up and running, more package authors will use the same patterns. Hope this is useful!