### PR TITLE
Simplify creating decreasing sequences

### DIFF
--- a/tiny-test.el
+++ b/tiny-test.el
@@ -213,4 +213,11 @@ SCHEDULED: <2015-11-12 Thu> DEADLINE: <2015-11-20 Fri>"))
     (should (equal (tiny-tokenize "(string x (upcase x) x") "(string x (upcase x) x)"))
     (should (equal (tiny-tokenize "(string x (upcase x) x)") "(string x (upcase x) x)")))
 
+(ert-deftest tiny-decreasing-seq ()
+  (should (equal (with-text-value "m2 -2" (lambda () (eval (read (tiny-mapconcat)))))
+                 "2 1 0 -1 -2"))
+  (should (equal (with-text-value "m3 -1|%(+ x x)" (lambda ()
+                                                     (eval (read (tiny-mapconcat)))))
+                 "6 4 2 0 -2")))
+
 (provide 'tiny-test)

--- a/tiny.el
+++ b/tiny.el
@@ -194,6 +194,8 @@ Defaults are used in place of null values."
              (fmt (car tes))
              (n-need (cl-count nil (cdr tes)))
              (idx -1)
+             (seq (number-sequence (read n0) (read n2)
+                                   (if (>= (read n0) (read n2)) -1 1)))
              (format-expression
               (concat "(mapconcat (lambda(x) (let ((lst %s)) (format %S "
                       (mapconcat (lambda (x)
@@ -203,15 +205,13 @@ Defaults are used in place of null values."
                                          (format "(nth %d lst)" (incf idx)))))
                                  (cdr tes)
                                  " ")
-                      ")))(number-sequence %s %s) \"%s\")")))
-        (unless (>= (read n0) (read n2))
-          (format
-           format-expression
-           expr
-           (replace-regexp-in-string "\\\\n" "\n" fmt)
-           n0
-           n2
-           s1))))))
+                      ")))'%S \"%s\")")))
+        (format
+         format-expression
+         expr
+         (replace-regexp-in-string "\\\\n" "\n" fmt)
+         seq
+         s1)))))
 
 (defconst tiny-format-str
   (let ((flags "[+ #-0]\\{0,1\\}")


### PR DESCRIPTION
Hi, I think I might have just missed the proper syntax for making decreasing sequences, but it appears that it requires additional lisp forms to be evaluated, ie `(- 4 x)`.  I made a minor change to `tiny-mapconcat` to allow for things like,
`m5 1`
to expand to `5 4 3 2 1`.  I hope I didn't break anything.  Anyway, just thought I would make a pull request if you're interested.